### PR TITLE
nrfx HAL: Align with nrfx version 2.0.0

### DIFF
--- a/src/nrfx/hal/nrf_clock.c
+++ b/src/nrfx/hal/nrf_clock.c
@@ -9,19 +9,26 @@
 #include "bs_tracing.h"
 #include "NRF_CLOCK.h"
 
-void nrf_clock_int_enable(uint32_t int_mask)
+void nrf_clock_int_enable(NRF_CLOCK_Type * p_reg, uint32_t mask)
 {
-  NRF_CLOCK->INTENSET = int_mask;
+  p_reg->INTENSET = mask;
   nrf_clock_reqw_sideeffects_INTENSET();
 }
 
-void nrf_clock_int_disable(uint32_t int_mask)
+void nrf_clock_int_disable(NRF_CLOCK_Type * p_reg, uint32_t mask)
 {
-  NRF_CLOCK->INTENCLR = int_mask;
+  p_reg->INTENCLR = mask;
   nrf_clock_reqw_sideeffects_INTENCLR();
 }
 
-void nrf_clock_task_trigger(nrf_clock_task_t task)
+uint32_t nrf_clock_int_enable_check(NRF_CLOCK_Type const * p_reg, uint32_t mask)
+{
+  /* Note that unlike the real NRF HW, INTENCLR is always
+   * reset to 0 by the HW models */
+  return p_reg->INTENSET & mask;
+}
+
+void nrf_clock_task_trigger(NRF_CLOCK_Type * p_reg, nrf_clock_task_t task)
 {
   if (task == NRF_CLOCK_TASK_HFCLKSTART) {
     NRF_CLOCK_regs.TASKS_HFCLKSTART = 1;
@@ -35,10 +42,4 @@ void nrf_clock_task_trigger(nrf_clock_task_t task)
   } else {
     bs_trace_error_line_time("Not supported task started in nrf_clock\n");
   }
-}
-
-bool nrf_clock_int_enable_check(nrf_clock_int_mask_t int_mask){
-  /* Note that unlike the real NRF HW, INTENCLR is always
-   * reset to 0 by the HW models */
-  return (bool)(NRF_CLOCK->INTENSET & int_mask);
 }

--- a/src/nrfx/hal/nrf_clock.h
+++ b/src/nrfx/hal/nrf_clock.h
@@ -185,63 +185,69 @@ typedef enum
 /**
  * @brief Function for enabling the specified interrupt.
  *
- * @param[in] int_mask Interrupt.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be enabled.
  */
-void nrf_clock_int_enable(uint32_t int_mask);
+void nrf_clock_int_enable(NRF_CLOCK_Type * p_reg, uint32_t mask);
 
 /**
  * @brief Function for disabling the specified interrupt.
  *
- * @param[in] int_mask Interrupt.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be disabled.
  */
-void nrf_clock_int_disable(uint32_t int_mask);
+void nrf_clock_int_disable(NRF_CLOCK_Type * p_reg, uint32_t mask);
 
 /**
- * @brief Function for retrieving the state of the specified interrupt.
+ * @brief Function for checking if the specified interrupts are enabled.
  *
- * @param[in] int_mask Interrupt.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be checked.
  *
- * @retval true  The interrupt is enabled.
- * @retval false The interrupt is not enabled.
+ * @return Mask of enabled interrupts.
  */
-bool nrf_clock_int_enable_check(nrf_clock_int_mask_t int_mask);
-
+uint32_t nrf_clock_int_enable_check(NRF_CLOCK_Type const * p_reg, uint32_t mask);
 
 /**
  * @brief Function for setting the specified task.
  *
- * @param[in] task Task to be activated.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] task  Task to be activated.
  */
-void nrf_clock_task_trigger(nrf_clock_task_t task);
-
+void nrf_clock_task_trigger(NRF_CLOCK_Type * p_reg, nrf_clock_task_t task);
 
 /**
  * @brief Function for clearing the specified event.
  *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  * @param[in] event Event to clear.
  */
-static inline void nrf_clock_event_clear(nrf_clock_event_t event);
+static inline void nrf_clock_event_clear(NRF_CLOCK_Type * p_reg, nrf_clock_event_t event);
 
 /**
  * @brief Function for retrieving the state of the specified event.
  *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  * @param[in] event Event to be checked.
  *
  * @retval true  The event has been generated.
  * @retval false The event has not been generated.
  */
-static inline bool nrf_clock_event_check(nrf_clock_event_t event);
+static inline bool nrf_clock_event_check(NRF_CLOCK_Type const * p_reg, nrf_clock_event_t event);
 
 /**
  * @brief Function for changing the low-frequency clock source.
  * @details This function cannot be called when the low-frequency clock is running.
  *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
  * @param[in] source New low-frequency clock source.
  */
-static inline void nrf_clock_lf_src_set(nrf_clock_lfclk_t source);
+static inline void nrf_clock_lf_src_set(NRF_CLOCK_Type * p_reg, nrf_clock_lfclk_t source);
 
 /**
  * @brief Function for retrieving the selected source for the low-frequency clock.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  *
  * @retval NRF_CLOCK_LFCLK_RC    The internal 32 kHz RC oscillator
  *                               is the selected source for the low-frequency clock.
@@ -250,29 +256,29 @@ static inline void nrf_clock_lf_src_set(nrf_clock_lfclk_t source);
  * @retval NRF_CLOCK_LFCLK_Synth The internal 32 kHz synthesizer from
  *                               the HFCLK is the selected source for the low-frequency clock.
  */
-static inline nrf_clock_lfclk_t nrf_clock_lf_src_get(void);
+static inline nrf_clock_lfclk_t nrf_clock_lf_src_get(NRF_CLOCK_Type const * p_reg);
 
 
 /* Bodies for inlined functions  */
 
-static inline void nrf_clock_event_clear(nrf_clock_event_t event)
+static inline void nrf_clock_event_clear(NRF_CLOCK_Type * p_reg, nrf_clock_event_t event)
 {
-    *((volatile uint32_t *)((uint8_t *)NRF_CLOCK + event)) = 0x0UL;
+    *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event)) = 0x0UL;
 }
 
-static inline bool nrf_clock_event_check(nrf_clock_event_t event)
+static inline bool nrf_clock_event_check(NRF_CLOCK_Type const * p_reg, nrf_clock_event_t event)
 {
-    return (bool)*((volatile uint32_t *)((uint8_t *)NRF_CLOCK + event));
+    return (bool)*((volatile uint32_t *)((uint8_t *)p_reg + event));
 }
 
-static inline void nrf_clock_lf_src_set(nrf_clock_lfclk_t source)
+static inline void nrf_clock_lf_src_set(NRF_CLOCK_Type * p_reg, nrf_clock_lfclk_t source)
 {
-    NRF_CLOCK->LFCLKSRC = (uint32_t)(source);
+    p_reg->LFCLKSRC = (uint32_t)(source);
 }
 
-static inline nrf_clock_lfclk_t nrf_clock_lf_src_get(void)
+static inline nrf_clock_lfclk_t nrf_clock_lf_src_get(NRF_CLOCK_Type const * p_reg)
 {
-    return (nrf_clock_lfclk_t)(NRF_CLOCK->LFCLKSRC);
+    return (nrf_clock_lfclk_t)(p_reg->LFCLKSRC);
 }
 #ifdef __cplusplus
 }

--- a/src/nrfx/hal/nrf_ppi.c
+++ b/src/nrfx/hal/nrf_ppi.c
@@ -9,40 +9,47 @@
 #include "NRF_PPI.h"
 #include "bs_tracing.h"
 
-void nrf_ppi_channels_disable(uint32_t mask){
-  NRF_PPI->CHENCLR = mask;
-  nrf_ppi_regw_sideeffects_CHENCLR();
-}
-
-void nrf_ppi_channels_enable(uint32_t mask){
-  NRF_PPI->CHENSET = mask;
+void nrf_ppi_channels_enable(NRF_PPI_Type * p_reg, uint32_t mask)
+{
+  p_reg->CHENSET = mask;
   nrf_ppi_regw_sideeffects_CHENSET();
 }
 
-void nrf_ppi_group_disable(nrf_ppi_channel_group_t group)
+void nrf_ppi_channels_disable(NRF_PPI_Type * p_reg, uint32_t mask)
 {
-  NRF_PPI->TASKS_CHG[(uint32_t) group].DIS = 1;
+  p_reg->CHENCLR = mask;
+  nrf_ppi_regw_sideeffects_CHENCLR();
+}
+
+void nrf_ppi_channel_endpoint_setup(NRF_PPI_Type *    p_reg,
+                                    nrf_ppi_channel_t channel,
+                                    uint32_t          eep,
+                                    uint32_t          tep)
+{
+  p_reg->CH[(uint32_t) channel].EEP = eep;
+  nrf_ppi_regw_sideeffects_EEP(channel);
+  p_reg->CH[(uint32_t) channel].TEP = tep;
+  nrf_ppi_regw_sideeffects_TEP(channel);
+}
+
+void nrf_ppi_event_endpoint_setup(NRF_PPI_Type *    p_reg,
+                                  nrf_ppi_channel_t channel,
+                                  uint32_t          eep)
+{
+  p_reg->CH[(uint32_t) channel].EEP = eep;
+  nrf_ppi_regw_sideeffects_EEP(channel);
+}
+
+void nrf_ppi_task_endpoint_setup(NRF_PPI_Type *    p_reg,
+                                 nrf_ppi_channel_t channel,
+                                 uint32_t          tep)
+{
+  p_reg->CH[(uint32_t) channel].TEP = tep;
+  nrf_ppi_regw_sideeffects_TEP(channel);
+}
+
+void nrf_ppi_group_disable(NRF_PPI_Type * p_reg, nrf_ppi_channel_group_t group)
+{
+  p_reg->TASKS_CHG[(uint32_t) group].DIS = 1;
   nrf_ppi_regw_sideeffects_TASKS_CHG_DIS(group);
-}
-
-void nrf_ppi_channel_endpoint_setup(nrf_ppi_channel_t channel,
-    uint32_t eep,
-    uint32_t tep)
-{
-  NRF_PPI->CH[(uint32_t) channel].EEP = eep;
-  nrf_ppi_regw_sideeffects_EEP(channel);
-  NRF_PPI->CH[(uint32_t) channel].TEP = tep;
-  nrf_ppi_regw_sideeffects_TEP(channel);
-}
-
-void nrf_ppi_event_endpoint_setup(nrf_ppi_channel_t channel,
-    uint32_t eep){
-  NRF_PPI->CH[(uint32_t) channel].EEP = eep;
-  nrf_ppi_regw_sideeffects_EEP(channel);
-}
-
-void nrf_ppi_task_endpoint_setup(nrf_ppi_channel_t channel,
-    uint32_t tep){
-  NRF_PPI->CH[(uint32_t) channel].TEP = tep;
-  nrf_ppi_regw_sideeffects_TEP(channel);
 }

--- a/src/nrfx/hal/nrf_ppi.h
+++ b/src/nrfx/hal/nrf_ppi.h
@@ -117,16 +117,19 @@ typedef enum
 #endif
 } nrf_ppi_channel_group_t;
 
-void nrf_ppi_channels_enable(uint32_t mask);
-void nrf_ppi_channels_disable(uint32_t mask);
-void nrf_ppi_channel_endpoint_setup(nrf_ppi_channel_t channel,
+void nrf_ppi_channels_enable(NRF_PPI_Type * p_reg, uint32_t mask);
+void nrf_ppi_channels_disable(NRF_PPI_Type * p_reg, uint32_t mask);
+void nrf_ppi_channel_endpoint_setup(NRF_PPI_Type *    p_reg,
+                                    nrf_ppi_channel_t channel,
                                     uint32_t          eep,
                                     uint32_t          tep);
-void nrf_ppi_event_endpoint_setup(nrf_ppi_channel_t channel,
+void nrf_ppi_event_endpoint_setup(NRF_PPI_Type *    p_reg,
+                                  nrf_ppi_channel_t channel,
                                   uint32_t          eep);
-void nrf_ppi_task_endpoint_setup(nrf_ppi_channel_t channel,
+void nrf_ppi_task_endpoint_setup(NRF_PPI_Type *    p_reg,
+                                 nrf_ppi_channel_t channel,
                                  uint32_t          tep);
-void nrf_ppi_group_disable(nrf_ppi_channel_group_t group);
+void nrf_ppi_group_disable(NRF_PPI_Type * p_reg, nrf_ppi_channel_group_t group);
 
 #ifdef __cplusplus
 }

--- a/src/nrfx/hal/nrf_radio.c
+++ b/src/nrfx/hal/nrf_radio.c
@@ -9,51 +9,36 @@
 #include "bs_tracing.h"
 #include "NRF_RADIO.h"
 
-void nrf_radio_int_enable(uint32_t radio_int_mask)
+void nrf_radio_task_trigger(NRF_RADIO_Type * p_reg, nrf_radio_task_t task)
 {
-  NRF_RADIO->INTENSET = radio_int_mask;
-  nrf_radio_regw_sideeffects_INTENSET();
-}
-
-/**
- * @brief Function for setting a specific task.
- *
- * @param[in]  radio_task              Task.
- */
-void nrf_radio_task_trigger(nrf_radio_task_t radio_task)
-{
-  if ( radio_task == NRF_RADIO_TASK_TXEN ) {
-    NRF_RADIO->TASKS_TXEN = 1;
+  if ( task == NRF_RADIO_TASK_TXEN ) {
+    p_reg->TASKS_TXEN = 1;
     nrf_radio_regw_sideeffects_TASKS_TXEN();
-  } else if ( radio_task == NRF_RADIO_TASK_RXEN ) {
-    NRF_RADIO->TASKS_RXEN = 1;
+  } else if ( task == NRF_RADIO_TASK_RXEN ) {
+    p_reg->TASKS_RXEN = 1;
     nrf_radio_regw_sideeffects_TASKS_RXEN();
-  } else if ( radio_task == NRF_RADIO_TASK_DISABLE ) {
-    NRF_RADIO->TASKS_DISABLE = 1;
+  } else if ( task == NRF_RADIO_TASK_DISABLE ) {
+    p_reg->TASKS_DISABLE = 1;
     nrf_radio_regw_sideeffects_TASKS_DISABLE();
   } else {
     bs_trace_error_line_time("Not supported task started in nrf_radio\n");
   }
 }
 
-/**
- * @brief Function for setting power mode of the radio peripheral.
- *
- * @param[in]  radio_power                  If radio should powered on.
- */
-void nrf_radio_power_set(bool radio_power)
+void nrf_radio_int_enable(NRF_RADIO_Type * p_reg, uint32_t mask)
 {
-  NRF_RADIO->POWER = (uint32_t) radio_power;
-  nrf_radio_regw_sideeffects_POWER();
+  p_reg->INTENSET = mask;
+  nrf_radio_regw_sideeffects_INTENSET();
 }
 
-/**
- * @brief Function for setting Bit counter compare.
- *
- * @param[in]  radio_bcc                    Bit counter compare [bits].
- */
-void nrf_radio_bcc_set(uint32_t radio_bcc)
+void nrf_radio_bcc_set(NRF_RADIO_Type * p_reg, uint32_t radio_bcc)
 {
-  NRF_RADIO->BCC = radio_bcc;
+  p_reg->BCC = radio_bcc;
   nrf_radio_regw_sideeffects_BCC();
+}
+
+void nrf_radio_power_set(NRF_RADIO_Type * p_reg, bool radio_power)
+{
+  p_reg->POWER = (uint32_t) radio_power;
+  nrf_radio_regw_sideeffects_POWER();
 }

--- a/src/nrfx/hal/nrf_radio.h
+++ b/src/nrfx/hal/nrf_radio.h
@@ -109,32 +109,36 @@ typedef enum
 } nrf_radio_int_mask_t;
 
 /**
- * @brief Function for enabling interrupts.
+ * @brief Function for activating a specific RADIO task.
  *
- * @param[in]  radio_int_mask              Mask of interrupts.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] task  Task to be activated.
  */
-void nrf_radio_int_enable(uint32_t radio_int_mask);
+void nrf_radio_task_trigger(NRF_RADIO_Type * p_reg, nrf_radio_task_t task);
 
 /**
- * @brief Function for setting a specific task.
+ * @brief Function for enabling specified RADIO interrupts.
  *
- * @param[in]  radio_task              Task.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be enabled.
  */
-void nrf_radio_task_trigger(nrf_radio_task_t radio_task);
-
-/**
- * @brief Function for setting power mode of the radio peripheral.
- *
- * @param[in]  radio_power                  If radio should powered on.
- */
-void nrf_radio_power_set(bool radio_power);
+void nrf_radio_int_enable(NRF_RADIO_Type * p_reg, uint32_t mask);
 
 /**
  * @brief Function for setting Bit counter compare.
  *
- * @param[in]  radio_bcc                    Bit counter compare [bits].
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] radio_bcc Bit counter compare [bits].
  */
-void nrf_radio_bcc_set(uint32_t radio_bcc);
+void nrf_radio_bcc_set(NRF_RADIO_Type * p_reg, uint32_t radio_bcc);
+
+/**
+ * @brief Function for setting power mode of the radio peripheral.
+ *
+ * @param[in] p_reg       Pointer to the structure of registers of the peripheral.
+ * @param[in] radio_power If radio should be powered on.
+ */
+void nrf_radio_power_set(NRF_RADIO_Type * p_reg, bool radio_power);
 
 #ifdef __cplusplus
 }

--- a/src/nrfx/hal/nrf_rng.c
+++ b/src/nrfx/hal/nrf_rng.c
@@ -9,9 +9,9 @@
 #include "bs_tracing.h"
 #include "NRF_RNG.h"
 
-void nrf_rng_task_trigger(nrf_rng_task_t rng_task)
+void nrf_rng_task_trigger(NRF_RNG_Type * p_reg, nrf_rng_task_t rng_task)
 {
-  *((volatile uint32_t *)((uint8_t *)NRF_RNG + rng_task)) = NRF_RNG_TASK_SET;
+  *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)rng_task)) = 0x1UL;
 
   if ( rng_task == NRF_RNG_TASK_START ) {
     NRF_RNG_regs.TASKS_START = 1;
@@ -24,14 +24,14 @@ void nrf_rng_task_trigger(nrf_rng_task_t rng_task)
   }
 }
 
-void nrf_rng_int_enable(uint32_t rng_int_mask)
+void nrf_rng_int_enable(NRF_RNG_Type * p_reg, uint32_t mask)
 {
-  NRF_RNG_regs.INTENSET = rng_int_mask;
+  NRF_RNG_regs.INTENSET = mask;
   nrf_rng_regw_sideeffects_INTENSET();
 }
 
-void nrf_rng_int_disable(uint32_t rng_int_mask)
+void nrf_rng_int_disable(NRF_RNG_Type * p_reg, uint32_t mask)
 {
-  NRF_RNG_regs.INTENCLR = rng_int_mask;
+  NRF_RNG_regs.INTENCLR = mask;
   nrf_rng_regw_sideeffects_INTENCLEAR();
 }

--- a/src/nrfx/hal/nrf_rng.h
+++ b/src/nrfx/hal/nrf_rng.h
@@ -56,9 +56,6 @@ extern "C" {
  * @brief   Hardware access layer for managing the Random Number Generator (RNG) peripheral.
  */
 
-#define NRF_RNG_TASK_SET    (1UL)
-#define NRF_RNG_EVENT_CLEAR (0UL)
-
 /**
  * @enum nrf_rng_task_t
  * @brief RNG tasks.
@@ -90,100 +87,111 @@ typedef enum
 /**
  * @brief Function for enabling interrupts.
  *
- * @param[in]  rng_int_mask              Mask of interrupts.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be enabled.
  */
-void nrf_rng_int_enable(uint32_t rng_int_mask);
+void nrf_rng_int_enable(NRF_RNG_Type * p_reg, uint32_t mask);
 
 /**
  * @brief Function for disabling interrupts.
  *
- * @param[in]  rng_int_mask              Mask of interrupts.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be disabled.
  */
-void nrf_rng_int_disable(uint32_t rng_int_mask);
+void nrf_rng_int_disable(NRF_RNG_Type * p_reg, uint32_t mask);
 
 /**
- * @brief Function for getting the state of a specific interrupt.
+ * @brief Function for checking if the specified interrupts are enabled.
  *
- * @param[in]  rng_int_mask              Interrupt.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be checked.
  *
- * @retval     true                   If the interrupt is not enabled.
- * @retval     false                  If the interrupt is enabled.
+ * @return Mask of enabled interrupts.
  */
-static inline bool nrf_rng_int_get(nrf_rng_int_mask_t rng_int_mask);
+static inline uint32_t nrf_rng_int_enable_check(NRF_RNG_Type const * p_reg, uint32_t mask);
 
 /**
- * @brief Function for setting a specific task.
+ * @brief Function for triggering the specified task.
  *
- * @param[in]  rng_task              Task.
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] rng_task The specified Task.
  */
-void nrf_rng_task_trigger(nrf_rng_task_t rng_task);
+void nrf_rng_task_trigger(NRF_RNG_Type * p_reg, nrf_rng_task_t rng_task);
 
 /**
- * @brief Function for clearing a specific event.
+ * @brief Function for clearing the specified event.
  *
- * @param[in]  rng_event              Event.
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] rng_event The specified event.
  */
-static inline void nrf_rng_event_clear(nrf_rng_event_t rng_event);
+static inline void nrf_rng_event_clear(NRF_RNG_Type * p_reg, nrf_rng_event_t rng_event);
 
 /**
- * @brief Function for getting the state of a specific event.
+ * @brief Function for retrieving the state of the specified event.
  *
- * @param[in]  rng_event              Event.
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
+ * @param[in] rng_event The specified event.
  *
- * @retval     true               If the event is not set.
- * @retval     false              If the event is set.
+ * @retval true  The event is set.
+ * @retval false The event is not set.
  */
-static inline bool nrf_rng_event_get(nrf_rng_event_t rng_event);
+static inline bool nrf_rng_event_check(NRF_RNG_Type const * p_reg, nrf_rng_event_t rng_event);
 
 /**
  * @brief Function for getting the previously generated random value.
  *
- * @return     Previously generated random value.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Previously generated random value.
  */
-static inline uint8_t nrf_rng_random_value_get(void);
+static inline uint8_t nrf_rng_random_value_get(NRF_RNG_Type const * p_reg);
 
 /**
  * @brief Function for enabling digital error correction.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  */
-static inline void nrf_rng_error_correction_enable(void);
+static inline void nrf_rng_error_correction_enable(NRF_RNG_Type * p_reg);
 
 /**
  * @brief Function for disabling digital error correction.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  */
-static inline void nrf_rng_error_correction_disable(void);
+static inline void nrf_rng_error_correction_disable(NRF_RNG_Type * p_reg);
 
 
 
 /* Bodies for inlined functions  */
 
-static inline bool nrf_rng_int_get(nrf_rng_int_mask_t rng_int_mask)
+static inline uint32_t nrf_rng_int_enable_check(NRF_RNG_Type const * p_reg, uint32_t mask)
 {
-    return (bool)(NRF_RNG->INTENSET & rng_int_mask);
+    return p_reg->INTENSET & mask;
 }
 
-static inline void nrf_rng_event_clear(nrf_rng_event_t rng_event)
+static inline void nrf_rng_event_clear(NRF_RNG_Type * p_reg, nrf_rng_event_t rng_event)
 {
-    *((volatile uint32_t *)((uint8_t *)NRF_RNG + rng_event)) = NRF_RNG_EVENT_CLEAR;
+    *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)rng_event)) = 0x0UL;
 }
 
-static inline bool nrf_rng_event_get(nrf_rng_event_t rng_event)
+static inline bool nrf_rng_event_check(NRF_RNG_Type const * p_reg, nrf_rng_event_t rng_event)
 {
-    return (bool) * ((volatile uint32_t *)((uint8_t *)NRF_RNG + rng_event));
+    return (bool) * ((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)rng_event));
 }
 
-static inline uint8_t nrf_rng_random_value_get(void)
+static inline uint8_t nrf_rng_random_value_get(NRF_RNG_Type const * p_reg)
 {
-    return (uint8_t)(NRF_RNG->VALUE & RNG_VALUE_VALUE_Msk);
+    return (uint8_t)(p_reg->VALUE & RNG_VALUE_VALUE_Msk);
 }
 
-static inline void nrf_rng_error_correction_enable(void)
+static inline void nrf_rng_error_correction_enable(NRF_RNG_Type * p_reg)
 {
-    NRF_RNG->CONFIG |= RNG_CONFIG_DERCEN_Msk;
+    p_reg->CONFIG |= RNG_CONFIG_DERCEN_Msk;
 }
 
-static inline void nrf_rng_error_correction_disable(void)
+static inline void nrf_rng_error_correction_disable(NRF_RNG_Type * p_reg)
 {
-    NRF_RNG->CONFIG &= ~RNG_CONFIG_DERCEN_Msk;
+    p_reg->CONFIG &= ~RNG_CONFIG_DERCEN_Msk;
 }
 
 #ifdef __cplusplus

--- a/src/nrfx/hal/nrf_rtc.c
+++ b/src/nrfx/hal/nrf_rtc.c
@@ -9,66 +9,67 @@
 #include "bs_tracing.h"
 #include "NRF_RTC.h"
 
-static int rtc_number_from_ptr(NRF_RTC_Type * p_rtc){
-  int i = ( (int)p_rtc - (int)&NRF_RTC_regs[0] ) / sizeof(NRF_RTC_Type);
+static int rtc_number_from_ptr(NRF_RTC_Type const * p_reg){
+  int i = ( (int)p_reg - (int)&NRF_RTC_regs[0] ) / sizeof(NRF_RTC_Type);
   return i;
 }
 
-void nrf_rtc_cc_set(NRF_RTC_Type * p_rtc, uint32_t ch, uint32_t cc_val)
+void nrf_rtc_cc_set(NRF_RTC_Type * p_reg, uint32_t ch, uint32_t cc_val)
 {
-  p_rtc->CC[ch] = cc_val;
-  int i = rtc_number_from_ptr(p_rtc);
+  p_reg->CC[ch] = cc_val;
+  int i = rtc_number_from_ptr(p_reg);
   nrf_rtc_regw_sideeffects_CC(i, ch);
 }
 
-void nrf_rtc_int_enable(NRF_RTC_Type * p_rtc, uint32_t mask)
+void nrf_rtc_int_enable(NRF_RTC_Type * p_reg, uint32_t mask)
 {
-  int i = rtc_number_from_ptr(p_rtc);
-  p_rtc->INTENSET = mask;
+  int i = rtc_number_from_ptr(p_reg);
+  p_reg->INTENSET = mask;
   nrf_rtc_regw_sideeffect_INTENSET(i);
 }
 
-void nrf_rtc_int_disable(NRF_RTC_Type * p_rtc, uint32_t mask)
+void nrf_rtc_int_disable(NRF_RTC_Type * p_reg, uint32_t mask)
 {
-  int i = rtc_number_from_ptr(p_rtc);
-  p_rtc->INTENCLR = mask;
+  int i = rtc_number_from_ptr(p_reg);
+  p_reg->INTENCLR = mask;
   nrf_rtc_regw_sideeffect_INTENCLR(i);
 }
 
-uint32_t nrf_rtc_counter_get(NRF_RTC_Type * p_rtc){
-  int i = rtc_number_from_ptr(p_rtc);
+uint32_t nrf_rtc_counter_get(NRF_RTC_Type const * p_reg)
+{
+  int i = rtc_number_from_ptr(p_reg);
   nrf_rtc_update_COUNTER(i);
-  return p_rtc->COUNTER;
+  return p_reg->COUNTER;
 }
 
-void nrf_rtc_task_trigger(NRF_RTC_Type * p_rtc, nrf_rtc_task_t task)
+void nrf_rtc_task_trigger(NRF_RTC_Type * p_reg, nrf_rtc_task_t task)
 {
-  int i = rtc_number_from_ptr(p_rtc);
+  int i = rtc_number_from_ptr(p_reg);
 
   if ( task == NRF_RTC_TASK_START ) {
-    p_rtc->TASKS_START = 1;
+    p_reg->TASKS_START = 1;
     nrf_rtc_regw_sideeffect_TASKS_START(i);
   } else if ( task == NRF_RTC_TASK_STOP ) {
-    p_rtc->TASKS_STOP = 1;
+    p_reg->TASKS_STOP = 1;
     nrf_rtc_regw_sideeffect_TASKS_STOP(i);
   } else if ( task == NRF_RTC_TASK_CLEAR ) {
-    p_rtc->TASKS_CLEAR = 1;
+    p_reg->TASKS_CLEAR = 1;
     nrf_rtc_regw_sideeffect_TASKS_CLEAR(i);
   } else {
     bs_trace_error_line_time("Not supported task started in nrf_rtc %i\n", i);
   }
 }
 
-void nrf_rtc_event_enable(NRF_RTC_Type * p_rtc, uint32_t mask)
+void nrf_rtc_event_enable(NRF_RTC_Type * p_reg, uint32_t mask)
 {
-  int i = rtc_number_from_ptr(p_rtc);
-  p_rtc->EVTENSET = mask;
+  int i = rtc_number_from_ptr(p_reg);
+  p_reg->EVTENSET = mask;
   nrf_rtc_regw_sideeffect_EVTENSET(i);
 }
 
-void nrf_rtc_event_disable(NRF_RTC_Type * p_rtc, uint32_t mask)
+void nrf_rtc_event_disable(NRF_RTC_Type * p_reg, uint32_t event)
 {
-  int i = rtc_number_from_ptr(p_rtc);
-  p_rtc->EVTENCLR = mask;
+  int i = rtc_number_from_ptr(p_reg);
+  p_reg->EVTENCLR = event;
   nrf_rtc_regw_sideeffect_EVTENCLR(i);
 }

--- a/src/nrfx/hal/nrf_rtc.h
+++ b/src/nrfx/hal/nrf_rtc.h
@@ -99,167 +99,172 @@ typedef enum
 
 
 
-/**@brief Function for setting a compare value for a channel.
+/**
+ * @brief Function for setting a compare value for a channel.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- * @param[in]  ch            Channel.
- * @param[in]  cc_val        Compare value to set.
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] ch     Channel.
+ * @param[in] cc_val Compare value to be set.
  */
-void nrf_rtc_cc_set(NRF_RTC_Type * p_rtc, uint32_t ch, uint32_t cc_val);
+void nrf_rtc_cc_set(NRF_RTC_Type * p_reg, uint32_t ch, uint32_t cc_val);
 
-/**@brief Function for returning the compare value for a channel.
+/**
+ * @brief Function for returning the compare value for a channel.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- * @param[in]  ch            Channel.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] ch    Channel.
  *
- * @return                   COMPARE[ch] value.
+ * @return COMPARE[ch] value.
  */
-__STATIC_INLINE uint32_t nrf_rtc_cc_get(NRF_RTC_Type * p_rtc, uint32_t ch);
+__STATIC_INLINE uint32_t nrf_rtc_cc_get(NRF_RTC_Type const * p_reg, uint32_t ch);
 
-/**@brief Function for enabling interrupts.
+/**
+ * @brief Function for enabling interrupts.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- * @param[in]  mask          Interrupt mask to be enabled.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Interrupt mask to be enabled.
  */
-void nrf_rtc_int_enable(NRF_RTC_Type * p_rtc, uint32_t mask);
+void nrf_rtc_int_enable(NRF_RTC_Type * p_reg, uint32_t mask);
 
-/**@brief Function for disabling interrupts.
+/**
+ * @brief Function for disabling interrupts.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- * @param[in]  mask          Interrupt mask to be disabled.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Interrupt mask to be disabled.
  */
-void nrf_rtc_int_disable(NRF_RTC_Type * p_rtc, uint32_t mask);
+void nrf_rtc_int_disable(NRF_RTC_Type * p_reg, uint32_t mask);
 
-/**@brief Function for checking if interrupts are enabled.
+/**
+ * @brief Function for checking if the specified interrupts are enabled.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- * @param[in]  mask          Mask of interrupt flags to check.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be checked.
  *
- * @return                   Mask with enabled interrupts.
+ * @return Mask of enabled interrupts.
  */
-__STATIC_INLINE uint32_t nrf_rtc_int_is_enabled(NRF_RTC_Type * p_rtc, uint32_t mask);
+__STATIC_INLINE uint32_t nrf_rtc_int_enable_check(NRF_RTC_Type const * p_reg, uint32_t mask);
 
-/**@brief Function for returning the status of currently enabled interrupts.
+/**
+ * @brief Function for retrieving the state of the RTC event.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] event Event to be checked.
  *
- * @return                   Value in INTEN register.
+ * @retval true  The event has been generated.
+ * @retval false The event has not been generated.
  */
-__STATIC_INLINE uint32_t nrf_rtc_int_get(NRF_RTC_Type * p_rtc);
+__STATIC_INLINE bool nrf_rtc_event_check(NRF_RTC_Type const * p_reg, nrf_rtc_event_t event);
 
-/**@brief Function for checking if an event is pending.
+/**
+ * @brief Function for clearing an event.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- * @param[in]  event         Address of the event.
- *
- * @return                   Mask of pending events.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] event Event to be cleared.
  */
-__STATIC_INLINE uint32_t nrf_rtc_event_pending(NRF_RTC_Type * p_rtc, nrf_rtc_event_t event);
+__STATIC_INLINE void nrf_rtc_event_clear(NRF_RTC_Type * p_reg, nrf_rtc_event_t event);
 
-/**@brief Function for clearing an event.
+/**
+ * @brief Function for returning a counter value.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- * @param[in]  event         Event to clear.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return Counter value.
  */
-__STATIC_INLINE void nrf_rtc_event_clear(NRF_RTC_Type * p_rtc, nrf_rtc_event_t event);
+uint32_t nrf_rtc_counter_get(NRF_RTC_Type const * p_reg);
 
-/**@brief Function for returning a counter value.
+/**
+ * @brief Function for setting a prescaler value.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- *
- * @return                   Counter value.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] val   Value to set the prescaler to.
  */
-uint32_t nrf_rtc_counter_get(NRF_RTC_Type * p_rtc);
+__STATIC_INLINE void nrf_rtc_prescaler_set(NRF_RTC_Type * p_reg, uint32_t val);
 
-/**@brief Function for setting a prescaler value.
+/**
+ * @brief Function for returning the address of an event.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- * @param[in]  val           Value to set the prescaler to.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] event Requested event.
+ *
+ * @return Address of the requested event register.
  */
-__STATIC_INLINE void nrf_rtc_prescaler_set(NRF_RTC_Type * p_rtc, uint32_t val);
+__STATIC_INLINE uint32_t nrf_rtc_event_address_get(NRF_RTC_Type const * p_reg,
+                                                     nrf_rtc_event_t      event);
 
-/**@brief Function for returning the address of an event.
+/**
+ * @brief Function for returning the address of a task.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- * @param[in]  event         Requested event.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] task  Requested task.
  *
- * @return     Address of the requested event register.
+ * @return Address of the requested task register.
  */
-__STATIC_INLINE uint32_t nrf_rtc_event_address_get(NRF_RTC_Type * p_rtc, nrf_rtc_event_t event);
+__STATIC_INLINE uint32_t nrf_rtc_task_address_get(NRF_RTC_Type const * p_reg,
+                                                    nrf_rtc_task_t       task);
 
-/**@brief Function for returning the address of a task.
+/**
+ * @brief Function for starting a task.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- * @param[in]  task          Requested task.
- *
- * @return     Address of the requested task register.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] task  Requested task.
  */
-__STATIC_INLINE uint32_t nrf_rtc_task_address_get(NRF_RTC_Type * p_rtc, nrf_rtc_task_t task);
+void nrf_rtc_task_trigger(NRF_RTC_Type * p_reg, nrf_rtc_task_t task);
 
-/**@brief Function for starting a task.
+/**
+ * @brief Function for enabling events.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- * @param[in]  task          Requested task.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of event flags to be enabled.
  */
-void nrf_rtc_task_trigger(NRF_RTC_Type * p_rtc, nrf_rtc_task_t task);
+void nrf_rtc_event_enable(NRF_RTC_Type * p_reg, uint32_t mask);
 
-
-/**@brief Function for enabling events.
+/**
+ * @brief Function for disabling an event.
  *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- * @param[in]  mask          Mask of event flags to enable.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] event Requested event.
  */
-void nrf_rtc_event_enable(NRF_RTC_Type * p_rtc, uint32_t mask);
-
-/**@brief Function for disabling an event.
- *
- * @param[in]  p_rtc         Pointer to the peripheral registers structure.
- * @param[in]  event         Requested event.
- */
-void nrf_rtc_event_disable(NRF_RTC_Type * p_rtc, uint32_t event);
+void nrf_rtc_event_disable(NRF_RTC_Type * p_reg, uint32_t event);
 
 /*****************************/
 /* Inlined functions bodies: */
 /*****************************/
 
-__STATIC_INLINE  uint32_t nrf_rtc_cc_get(NRF_RTC_Type * p_rtc, uint32_t ch)
+__STATIC_INLINE uint32_t nrf_rtc_cc_get(NRF_RTC_Type const * p_reg, uint32_t ch)
 {
-    return p_rtc->CC[ch];
+    return p_reg->CC[ch];
 }
 
-__STATIC_INLINE uint32_t nrf_rtc_int_is_enabled(NRF_RTC_Type * p_rtc, uint32_t mask)
+__STATIC_INLINE uint32_t nrf_rtc_int_enable_check(NRF_RTC_Type const * p_reg, uint32_t mask)
 {
-    return (p_rtc->INTENSET & mask);
+    return p_reg->INTENSET & mask;
 }
 
-__STATIC_INLINE uint32_t nrf_rtc_int_get(NRF_RTC_Type * p_rtc)
+__STATIC_INLINE bool nrf_rtc_event_check(NRF_RTC_Type const * p_reg, nrf_rtc_event_t event)
 {
-    return p_rtc->INTENSET;
+    return (bool)*(volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event);
 }
 
-__STATIC_INLINE uint32_t nrf_rtc_event_pending(NRF_RTC_Type * p_rtc, nrf_rtc_event_t event)
+__STATIC_INLINE void nrf_rtc_event_clear(NRF_RTC_Type * p_reg, nrf_rtc_event_t event)
 {
-    return *(volatile uint32_t *)((uint8_t *)p_rtc + (uint32_t)event);
+    *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event)) = 0;
 }
 
-__STATIC_INLINE void nrf_rtc_event_clear(NRF_RTC_Type * p_rtc, nrf_rtc_event_t event)
+__STATIC_INLINE void nrf_rtc_prescaler_set(NRF_RTC_Type * p_reg, uint32_t val)
 {
-    *((volatile uint32_t *)((uint8_t *)p_rtc + (uint32_t)event)) = 0;
+    p_reg->PRESCALER = val;
 }
 
-__STATIC_INLINE void nrf_rtc_prescaler_set(NRF_RTC_Type * p_rtc, uint32_t val)
+__STATIC_INLINE uint32_t nrf_rtc_event_address_get(NRF_RTC_Type const * p_reg,
+                                                   nrf_rtc_event_t      event)
 {
-    p_rtc->PRESCALER = val;
+    return (uint32_t)p_reg + event;
 }
 
-__STATIC_INLINE uint32_t nrf_rtc_event_address_get(NRF_RTC_Type * p_rtc, nrf_rtc_event_t event)
+__STATIC_INLINE uint32_t nrf_rtc_task_address_get(NRF_RTC_Type const * p_reg,
+                                                  nrf_rtc_task_t       task)
 {
-    return (uint32_t)p_rtc + event;
-}
-
-__STATIC_INLINE uint32_t nrf_rtc_task_address_get(NRF_RTC_Type * p_rtc, nrf_rtc_task_t task)
-{
-    return (uint32_t)p_rtc + task;
+    return (uint32_t)p_reg + task;
 }
 
 #ifdef __cplusplus

--- a/src/nrfx/hal/nrf_timer.c
+++ b/src/nrfx/hal/nrf_timer.c
@@ -14,7 +14,7 @@ static int timer_number_from_ptr(NRF_TIMER_Type * p_reg){
   return i;
 }
 
-void nrf_timer_cc_write(NRF_TIMER_Type * p_reg,
+void nrf_timer_cc_set(NRF_TIMER_Type * p_reg,
     nrf_timer_cc_channel_t cc_channel,
     uint32_t               cc_value)
 {

--- a/src/nrfx/hal/nrf_timer.h
+++ b/src/nrfx/hal/nrf_timer.h
@@ -70,6 +70,12 @@ typedef enum
 #if defined(TIMER_INTENSET_COMPARE5_Msk) || defined(__NRFX_DOXYGEN__)
     NRF_TIMER_TASK_CAPTURE5 = offsetof(NRF_TIMER_Type, TASKS_CAPTURE[5]), ///< Task for capturing the timer value on channel 5.
 #endif
+#if defined(TIMER_INTENSET_COMPARE6_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_TIMER_TASK_CAPTURE6 = offsetof(NRF_TIMER_Type, TASKS_CAPTURE[6]), ///< Task for capturing the timer value on channel 6.
+#endif
+#if defined(TIMER_INTENSET_COMPARE7_Msk) || defined(__NRFX_DOXYGEN__)
+    NRF_TIMER_TASK_CAPTURE7 = offsetof(NRF_TIMER_Type, TASKS_CAPTURE[7]), ///< Task for capturing the timer value on channel 7.
+#endif
     /*lint -restore*/
 } nrf_timer_task_t;
 
@@ -91,24 +97,24 @@ typedef enum
 } nrf_timer_cc_channel_t;
 
 /**
- * @brief Function for activating a specific timer task.
+ * @brief Function for activating the specified timer task.
  *
- * @param[in] p_reg   Pointer to the peripheral registers structure.
- * @param[in] task    Task to activate.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] task  Task to be activated.
  */
 void nrf_timer_task_trigger(NRF_TIMER_Type * p_reg,
-                                            nrf_timer_task_t task);
+                            nrf_timer_task_t task);
 
 /**
- * @brief Function for writing the capture/compare register for a specified channel.
+ * @brief Function for setting the capture/compare register for the specified channel.
  *
- * @param[in] p_reg      Pointer to the peripheral registers structure.
- * @param[in] cc_channel Requested capture/compare channel.
+ * @param[in] p_reg      Pointer to the structure of registers of the peripheral.
+ * @param[in] cc_channel The specified capture/compare channel.
  * @param[in] cc_value   Value to write to the capture/compare register.
  */
-void nrf_timer_cc_write(NRF_TIMER_Type * p_reg,
-                                        nrf_timer_cc_channel_t cc_channel,
-                                        uint32_t               cc_value);
+void nrf_timer_cc_set(NRF_TIMER_Type *       p_reg,
+                      nrf_timer_cc_channel_t cc_channel,
+                      uint32_t               cc_value);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Needed in order to integrate nrfx 2.0.0 into Zephyr.
Tested in https://github.com/zephyrproject-rtos/zephyr/pull/20436 by using [this temporary patch](https://github.com/zephyrproject-rtos/zephyr/pull/20436/commits/07712eabcca326013858024b1e2bf963e0c350f0#diff-d8a0e523e68ccf71d1f516f9db119ae5).