### PR TITLE
nrfx HAL: Add nrf_clock_is_running

### DIFF
--- a/src/nrfx/hal/nrf_soc_if.h
+++ b/src/nrfx/hal/nrf_soc_if.h
@@ -82,6 +82,8 @@ extern void __SEV(void);
 extern void NVIC_SetPendingIRQ(IRQn_Type IRQn);
 extern void NVIC_ClearPendingIRQ(IRQn_Type IRQn);
 
+#define NRFX_ASSERT(...)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Added call that is now used by the clock control driver.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>