### PR TITLE
Add stubbed GPIO/GPIOTE/TEMP and mocked nrf.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ if(CONFIG_BOARD_NRF52_BSIM)
   zephyr_include_directories(
     src/
     src/nrfx/hal/
+    src/nrfx/mdk
     src/nrfx/
     src/HW_models/
   )

--- a/src/HW_models/NRF_GPIO.c
+++ b/src/HW_models/NRF_GPIO.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "NRF_GPIO.h"
+
+/*
+ * This is only a stub of the register interface with no functionality behind
+ */
+
+NRF_GPIO_Type NRF_P0_regs = {0};

--- a/src/HW_models/NRF_GPIO.h
+++ b/src/HW_models/NRF_GPIO.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef _NRF_HW_MODEL_GPIO_H
+#define _NRF_HW_MODEL_GPIO_H
+
+#include "NRF_regs.h"
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+extern NRF_GPIO_Type NRF_P0_regs;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/HW_models/NRF_GPIOTE.c
+++ b/src/HW_models/NRF_GPIOTE.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "NRF_GPIOTE.h"
+
+/*
+ * This is only a stub of the register interface with no functionality behind
+ */
+
+NRF_GPIOTE_Type NRF_GPIOTE_regs = {0};

--- a/src/HW_models/NRF_GPIOTE.h
+++ b/src/HW_models/NRF_GPIOTE.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef _NRF_HW_MODEL_GPIOTE_H
+#define _NRF_HW_MODEL_GPIOTE_H
+
+#include "NRF_regs.h"
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+extern NRF_GPIOTE_Type NRF_GPIOTE_regs;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/HW_models/NRF_TEMP.c
+++ b/src/HW_models/NRF_TEMP.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "NRF_TEMP.h"
+
+/*
+ * This is only a stub of the register interface with no functionality behind
+ */
+
+NRF_TEMP_Type NRF_TEMP_regs = {0};

--- a/src/HW_models/NRF_TEMP.h
+++ b/src/HW_models/NRF_TEMP.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef _NRF_HW_MODEL_TEMP_H
+#define _NRF_HW_MODEL_TEMP_H
+
+#include "NRF_regs.h"
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+extern NRF_TEMP_Type NRF_TEMP_regs;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/nrfx/hal/nrf_gpio.h
+++ b/src/nrfx/hal/nrf_gpio.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef BS_NRF_GPIO_H__
+#define BS_NRF_GPIO_H__
+
+#include "../drivers/nrfx_common.h"
+
+#endif /* BS_NRF_GPIO_H__ */

--- a/src/nrfx/hal/nrf_gpiote.h
+++ b/src/nrfx/hal/nrf_gpiote.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef BS_NRF_GPIOTE_H__
+#define BS_NRF_GPIOTE_H__
+
+#include "../drivers/nrfx_common.h"
+
+#endif /* BS_NRF_TIMER_H__ */

--- a/src/nrfx/hal/nrf_soc_if.h
+++ b/src/nrfx/hal/nrf_soc_if.h
@@ -75,6 +75,13 @@ extern NRF_TIMER_Type NRF_TIMER_regs[];
 #define NRF_TIMER4_BASE                   (&NRF_TIMER_regs[4])
 extern NRF_POWER_Type NRF_POWER_regs;
 #define NRF_POWER_BASE                    (&NRF_POWER_regs)
+extern NRF_GPIO_Type NRF_P0_regs;
+#undef NRF_P0_BASE
+#define NRF_P0_BASE                       (&NRF_P0_regs)
+extern NRF_GPIOTE_Type NRF_GPIOTE_regs;
+#undef NRF_GPIOTE_BASE
+#define NRF_GPIOTE_BASE                   (&NRF_GPIOTE_regs)
+
 
 /**
  * Note that the model of the CPU & IRQ controller driver must provide

--- a/src/nrfx/hal/nrf_soc_if.h
+++ b/src/nrfx/hal/nrf_soc_if.h
@@ -36,6 +36,9 @@ extern NRF_AAR_Type NRF_AAR_regs;
 extern NRF_RNG_Type NRF_RNG_regs;
 #undef NRF_RNG_BASE
 #define NRF_RNG_BASE                      (&NRF_RNG_regs)
+extern NRF_TEMP_Type NRF_TEMP_regs;
+#undef NRF_TEMP_BASE
+#define NRF_TEMP_BASE                     (&NRF_TEMP_regs)
 extern NRF_RTC_Type NRF_RTC_regs[];
 #undef NRF_RTC0_BASE
 #define NRF_RTC0_BASE                     (&NRF_RTC_regs[0])

--- a/src/nrfx/hal/nrf_soc_if.h
+++ b/src/nrfx/hal/nrf_soc_if.h
@@ -85,6 +85,12 @@ extern void __SEV(void);
 extern void NVIC_SetPendingIRQ(IRQn_Type IRQn);
 extern void NVIC_ClearPendingIRQ(IRQn_Type IRQn);
 
+/**
+ * Add empty implementations for some functions that don't need to be simulated.
+ */
+static inline void __DMB() {}
+static inline void __NOP() {}
+
 #define NRFX_ASSERT(...)
 
 #ifdef __cplusplus

--- a/src/nrfx/hal/nrf_temp.h
+++ b/src/nrfx/hal/nrf_temp.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef BS_NRF_TEMP_H__
+#define BS_NRF_TEMP_H__
+
+#include "../drivers/nrfx_common.h"
+
+#endif /* BS_NRF_TEMP_H__ */

--- a/src/nrfx/mdk/nrf.h
+++ b/src/nrfx/mdk/nrf.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef NRF_H__
+#define NRF_H__
+
+/* Only include the type definitions of the registers.
+ *
+ * This file will allow code to be compiled for either the real or
+ * mocked HW. */
+
+#include "NRF_regs.h"
+
+#endif


### PR DESCRIPTION
This PR makes it possible to use the HW models for more types of applications.

1. Now it is possible to link applications that access the GPIO/GPIOTE/TEMP peripheral. These periperals are not yet simulated. In either case it makes it easier to get started.
2. Applications that include nrf.h. With the addition of a mocked header file, there is no need to change the existing implementation and APIs