### PR TITLE
HAL: Add and use NRF_STATIC_INLINE

### DIFF
--- a/src/nrfx/drivers/nrfx_common.h
+++ b/src/nrfx/drivers/nrfx_common.h
@@ -50,6 +50,22 @@
 extern "C" {
 #endif
 
+#ifndef NRFX_STATIC_INLINE
+#ifdef NRFX_DECLARE_ONLY
+#define NRFX_STATIC_INLINE
+#else
+#define NRFX_STATIC_INLINE static inline
+#endif
+#endif // NRFX_STATIC_INLINE
+
+#ifndef NRF_STATIC_INLINE
+#ifdef NRF_DECLARE_ONLY
+#define NRF_STATIC_INLINE
+#else
+#define NRF_STATIC_INLINE static inline
+#endif
+#endif // NRF_STATIC_INLINE
+
 /**
  * @defgroup nrfx_common Common module
  * @{
@@ -173,12 +189,12 @@ unsigned int nrfx_peripheral_from_base_address(void const * p_reg);
  */
 #define NRFX_IRQ_NUMBER_GET(base_addr)  NRFX_PERIPHERAL_ID_GET(base_addr)
 
-static inline bool nrfx_is_word_aligned(void const * p_object)
+NRF_STATIC_INLINE bool nrfx_is_word_aligned(void const * p_object)
 {
     return ((((uint32_t)p_object) & 0x3u) == 0u);
 }
 
-static inline IRQn_Type nrfx_get_irq_number(void const * p_reg)
+NRF_STATIC_INLINE IRQn_Type nrfx_get_irq_number(void const * p_reg)
 {
     return (IRQn_Type)NRFX_IRQ_NUMBER_GET(p_reg);
 }

--- a/src/nrfx/hal/nrf_clock.h
+++ b/src/nrfx/hal/nrf_clock.h
@@ -251,7 +251,7 @@ void nrf_clock_task_trigger(NRF_CLOCK_Type * p_reg, nrf_clock_task_t task);
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  * @param[in] event Event to clear.
  */
-static inline void nrf_clock_event_clear(NRF_CLOCK_Type * p_reg, nrf_clock_event_t event);
+NRF_STATIC_INLINE void nrf_clock_event_clear(NRF_CLOCK_Type * p_reg, nrf_clock_event_t event);
 
 /**
  * @brief Function for retrieving the state of the specified event.
@@ -262,7 +262,7 @@ static inline void nrf_clock_event_clear(NRF_CLOCK_Type * p_reg, nrf_clock_event
  * @retval true  The event has been generated.
  * @retval false The event has not been generated.
  */
-static inline bool nrf_clock_event_check(NRF_CLOCK_Type const * p_reg, nrf_clock_event_t event);
+NRF_STATIC_INLINE bool nrf_clock_event_check(NRF_CLOCK_Type const * p_reg, nrf_clock_event_t event);
 
 /**
  * @brief Function for changing the low-frequency clock source.
@@ -271,7 +271,7 @@ static inline bool nrf_clock_event_check(NRF_CLOCK_Type const * p_reg, nrf_clock
  * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
  * @param[in] source New low-frequency clock source.
  */
-static inline void nrf_clock_lf_src_set(NRF_CLOCK_Type * p_reg, nrf_clock_lfclk_t source);
+NRF_STATIC_INLINE void nrf_clock_lf_src_set(NRF_CLOCK_Type * p_reg, nrf_clock_lfclk_t source);
 
 /**
  * @brief Function for retrieving the selected source for the low-frequency clock.
@@ -285,32 +285,32 @@ static inline void nrf_clock_lf_src_set(NRF_CLOCK_Type * p_reg, nrf_clock_lfclk_
  * @retval NRF_CLOCK_LFCLK_Synth The internal 32 kHz synthesizer from
  *                               the HFCLK is the selected source for the low-frequency clock.
  */
-static inline nrf_clock_lfclk_t nrf_clock_lf_src_get(NRF_CLOCK_Type const * p_reg);
+NRF_STATIC_INLINE nrf_clock_lfclk_t nrf_clock_lf_src_get(NRF_CLOCK_Type const * p_reg);
 
 
 /* Bodies for inlined functions  */
 
-static inline void nrf_clock_event_clear(NRF_CLOCK_Type * p_reg, nrf_clock_event_t event)
+NRF_STATIC_INLINE void nrf_clock_event_clear(NRF_CLOCK_Type * p_reg, nrf_clock_event_t event)
 {
     *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event)) = 0x0UL;
 }
 
-static inline bool nrf_clock_event_check(NRF_CLOCK_Type const * p_reg, nrf_clock_event_t event)
+NRF_STATIC_INLINE bool nrf_clock_event_check(NRF_CLOCK_Type const * p_reg, nrf_clock_event_t event)
 {
     return (bool)*((volatile uint32_t *)((uint8_t *)p_reg + event));
 }
 
-static inline void nrf_clock_lf_src_set(NRF_CLOCK_Type * p_reg, nrf_clock_lfclk_t source)
+NRF_STATIC_INLINE void nrf_clock_lf_src_set(NRF_CLOCK_Type * p_reg, nrf_clock_lfclk_t source)
 {
     p_reg->LFCLKSRC = (uint32_t)(source);
 }
 
-static inline nrf_clock_lfclk_t nrf_clock_lf_src_get(NRF_CLOCK_Type const * p_reg)
+NRF_STATIC_INLINE nrf_clock_lfclk_t nrf_clock_lf_src_get(NRF_CLOCK_Type const * p_reg)
 {
     return (nrf_clock_lfclk_t)(p_reg->LFCLKSRC);
 }
 
-static inline bool nrf_clock_is_running(NRF_CLOCK_Type const * p_reg,
+NRF_STATIC_INLINE bool nrf_clock_is_running(NRF_CLOCK_Type const * p_reg,
                                         nrf_clock_domain_t     domain,
                                         void *                 p_clk_src)
 {

--- a/src/nrfx/hal/nrf_rng.h
+++ b/src/nrfx/hal/nrf_rng.h
@@ -108,7 +108,7 @@ void nrf_rng_int_disable(NRF_RNG_Type * p_reg, uint32_t mask);
  *
  * @return Mask of enabled interrupts.
  */
-static inline uint32_t nrf_rng_int_enable_check(NRF_RNG_Type const * p_reg, uint32_t mask);
+NRF_STATIC_INLINE uint32_t nrf_rng_int_enable_check(NRF_RNG_Type const * p_reg, uint32_t mask);
 
 /**
  * @brief Function for triggering the specified task.
@@ -124,7 +124,7 @@ void nrf_rng_task_trigger(NRF_RNG_Type * p_reg, nrf_rng_task_t rng_task);
  * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
  * @param[in] rng_event The specified event.
  */
-static inline void nrf_rng_event_clear(NRF_RNG_Type * p_reg, nrf_rng_event_t rng_event);
+NRF_STATIC_INLINE void nrf_rng_event_clear(NRF_RNG_Type * p_reg, nrf_rng_event_t rng_event);
 
 /**
  * @brief Function for retrieving the state of the specified event.
@@ -135,7 +135,7 @@ static inline void nrf_rng_event_clear(NRF_RNG_Type * p_reg, nrf_rng_event_t rng
  * @retval true  The event is set.
  * @retval false The event is not set.
  */
-static inline bool nrf_rng_event_check(NRF_RNG_Type const * p_reg, nrf_rng_event_t rng_event);
+NRF_STATIC_INLINE bool nrf_rng_event_check(NRF_RNG_Type const * p_reg, nrf_rng_event_t rng_event);
 
 /**
  * @brief Function for getting the previously generated random value.
@@ -144,52 +144,52 @@ static inline bool nrf_rng_event_check(NRF_RNG_Type const * p_reg, nrf_rng_event
  *
  * @return Previously generated random value.
  */
-static inline uint8_t nrf_rng_random_value_get(NRF_RNG_Type const * p_reg);
+NRF_STATIC_INLINE uint8_t nrf_rng_random_value_get(NRF_RNG_Type const * p_reg);
 
 /**
  * @brief Function for enabling digital error correction.
  *
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  */
-static inline void nrf_rng_error_correction_enable(NRF_RNG_Type * p_reg);
+NRF_STATIC_INLINE void nrf_rng_error_correction_enable(NRF_RNG_Type * p_reg);
 
 /**
  * @brief Function for disabling digital error correction.
  *
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  */
-static inline void nrf_rng_error_correction_disable(NRF_RNG_Type * p_reg);
+NRF_STATIC_INLINE void nrf_rng_error_correction_disable(NRF_RNG_Type * p_reg);
 
 
 
 /* Bodies for inlined functions  */
 
-static inline uint32_t nrf_rng_int_enable_check(NRF_RNG_Type const * p_reg, uint32_t mask)
+NRF_STATIC_INLINE uint32_t nrf_rng_int_enable_check(NRF_RNG_Type const * p_reg, uint32_t mask)
 {
     return p_reg->INTENSET & mask;
 }
 
-static inline void nrf_rng_event_clear(NRF_RNG_Type * p_reg, nrf_rng_event_t rng_event)
+NRF_STATIC_INLINE void nrf_rng_event_clear(NRF_RNG_Type * p_reg, nrf_rng_event_t rng_event)
 {
     *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)rng_event)) = 0x0UL;
 }
 
-static inline bool nrf_rng_event_check(NRF_RNG_Type const * p_reg, nrf_rng_event_t rng_event)
+NRF_STATIC_INLINE bool nrf_rng_event_check(NRF_RNG_Type const * p_reg, nrf_rng_event_t rng_event)
 {
     return (bool) * ((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)rng_event));
 }
 
-static inline uint8_t nrf_rng_random_value_get(NRF_RNG_Type const * p_reg)
+NRF_STATIC_INLINE uint8_t nrf_rng_random_value_get(NRF_RNG_Type const * p_reg)
 {
     return (uint8_t)(p_reg->VALUE & RNG_VALUE_VALUE_Msk);
 }
 
-static inline void nrf_rng_error_correction_enable(NRF_RNG_Type * p_reg)
+NRF_STATIC_INLINE void nrf_rng_error_correction_enable(NRF_RNG_Type * p_reg)
 {
     p_reg->CONFIG |= RNG_CONFIG_DERCEN_Msk;
 }
 
-static inline void nrf_rng_error_correction_disable(NRF_RNG_Type * p_reg)
+NRF_STATIC_INLINE void nrf_rng_error_correction_disable(NRF_RNG_Type * p_reg)
 {
     p_reg->CONFIG &= ~RNG_CONFIG_DERCEN_Msk;
 }

--- a/src/nrfx/hal/nrf_rtc.h
+++ b/src/nrfx/hal/nrf_rtc.h
@@ -45,10 +45,6 @@
 #include "nrf_soc_if.h"
 #include "../drivers/nrfx_common.h"
 
-#ifndef __STATIC_INLINE
-#define __STATIC_INLINE static inline
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -98,7 +94,6 @@ typedef enum
 } nrf_rtc_int_t;
 
 
-
 /**
  * @brief Function for setting a compare value for a channel.
  *
@@ -116,7 +111,7 @@ void nrf_rtc_cc_set(NRF_RTC_Type * p_reg, uint32_t ch, uint32_t cc_val);
  *
  * @return COMPARE[ch] value.
  */
-__STATIC_INLINE uint32_t nrf_rtc_cc_get(NRF_RTC_Type const * p_reg, uint32_t ch);
+NRF_STATIC_INLINE  uint32_t nrf_rtc_cc_get(NRF_RTC_Type const * p_reg, uint32_t ch);
 
 /**
  * @brief Function for enabling interrupts.
@@ -142,7 +137,7 @@ void nrf_rtc_int_disable(NRF_RTC_Type * p_reg, uint32_t mask);
  *
  * @return Mask of enabled interrupts.
  */
-__STATIC_INLINE uint32_t nrf_rtc_int_enable_check(NRF_RTC_Type const * p_reg, uint32_t mask);
+NRF_STATIC_INLINE uint32_t nrf_rtc_int_enable_check(NRF_RTC_Type const * p_reg, uint32_t mask);
 
 /**
  * @brief Function for retrieving the state of the RTC event.
@@ -153,7 +148,7 @@ __STATIC_INLINE uint32_t nrf_rtc_int_enable_check(NRF_RTC_Type const * p_reg, ui
  * @retval true  The event has been generated.
  * @retval false The event has not been generated.
  */
-__STATIC_INLINE bool nrf_rtc_event_check(NRF_RTC_Type const * p_reg, nrf_rtc_event_t event);
+NRF_STATIC_INLINE bool nrf_rtc_event_check(NRF_RTC_Type const * p_reg, nrf_rtc_event_t event);
 
 /**
  * @brief Function for clearing an event.
@@ -161,7 +156,7 @@ __STATIC_INLINE bool nrf_rtc_event_check(NRF_RTC_Type const * p_reg, nrf_rtc_eve
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  * @param[in] event Event to be cleared.
  */
-__STATIC_INLINE void nrf_rtc_event_clear(NRF_RTC_Type * p_reg, nrf_rtc_event_t event);
+NRF_STATIC_INLINE void nrf_rtc_event_clear(NRF_RTC_Type * p_reg, nrf_rtc_event_t event);
 
 /**
  * @brief Function for returning a counter value.
@@ -178,7 +173,7 @@ uint32_t nrf_rtc_counter_get(NRF_RTC_Type const * p_reg);
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  * @param[in] val   Value to set the prescaler to.
  */
-__STATIC_INLINE void nrf_rtc_prescaler_set(NRF_RTC_Type * p_reg, uint32_t val);
+NRF_STATIC_INLINE void nrf_rtc_prescaler_set(NRF_RTC_Type * p_reg, uint32_t val);
 
 /**
  * @brief Function for returning the address of an event.
@@ -188,7 +183,7 @@ __STATIC_INLINE void nrf_rtc_prescaler_set(NRF_RTC_Type * p_reg, uint32_t val);
  *
  * @return Address of the requested event register.
  */
-__STATIC_INLINE uint32_t nrf_rtc_event_address_get(NRF_RTC_Type const * p_reg,
+NRF_STATIC_INLINE uint32_t nrf_rtc_event_address_get(NRF_RTC_Type const * p_reg,
                                                      nrf_rtc_event_t      event);
 
 /**
@@ -199,7 +194,7 @@ __STATIC_INLINE uint32_t nrf_rtc_event_address_get(NRF_RTC_Type const * p_reg,
  *
  * @return Address of the requested task register.
  */
-__STATIC_INLINE uint32_t nrf_rtc_task_address_get(NRF_RTC_Type const * p_reg,
+NRF_STATIC_INLINE uint32_t nrf_rtc_task_address_get(NRF_RTC_Type const * p_reg,
                                                     nrf_rtc_task_t       task);
 
 /**
@@ -230,39 +225,39 @@ void nrf_rtc_event_disable(NRF_RTC_Type * p_reg, uint32_t event);
 /* Inlined functions bodies: */
 /*****************************/
 
-__STATIC_INLINE uint32_t nrf_rtc_cc_get(NRF_RTC_Type const * p_reg, uint32_t ch)
+NRF_STATIC_INLINE  uint32_t nrf_rtc_cc_get(NRF_RTC_Type const * p_reg, uint32_t ch)
 {
     return p_reg->CC[ch];
 }
 
-__STATIC_INLINE uint32_t nrf_rtc_int_enable_check(NRF_RTC_Type const * p_reg, uint32_t mask)
+NRF_STATIC_INLINE uint32_t nrf_rtc_int_enable_check(NRF_RTC_Type const * p_reg, uint32_t mask)
 {
     return p_reg->INTENSET & mask;
 }
 
-__STATIC_INLINE bool nrf_rtc_event_check(NRF_RTC_Type const * p_reg, nrf_rtc_event_t event)
+NRF_STATIC_INLINE bool nrf_rtc_event_check(NRF_RTC_Type const * p_reg, nrf_rtc_event_t event)
 {
     return (bool)*(volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event);
 }
 
-__STATIC_INLINE void nrf_rtc_event_clear(NRF_RTC_Type * p_reg, nrf_rtc_event_t event)
+NRF_STATIC_INLINE void nrf_rtc_event_clear(NRF_RTC_Type * p_reg, nrf_rtc_event_t event)
 {
     *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event)) = 0;
 }
 
-__STATIC_INLINE void nrf_rtc_prescaler_set(NRF_RTC_Type * p_reg, uint32_t val)
+NRF_STATIC_INLINE void nrf_rtc_prescaler_set(NRF_RTC_Type * p_reg, uint32_t val)
 {
     p_reg->PRESCALER = val;
 }
 
-__STATIC_INLINE uint32_t nrf_rtc_event_address_get(NRF_RTC_Type const * p_reg,
-                                                   nrf_rtc_event_t      event)
+NRF_STATIC_INLINE uint32_t nrf_rtc_event_address_get(NRF_RTC_Type const * p_reg,
+                                                     nrf_rtc_event_t      event)
 {
     return (uint32_t)p_reg + event;
 }
 
-__STATIC_INLINE uint32_t nrf_rtc_task_address_get(NRF_RTC_Type const * p_reg,
-                                                  nrf_rtc_task_t       task)
+NRF_STATIC_INLINE uint32_t nrf_rtc_task_address_get(NRF_RTC_Type const * p_reg,
+                                                    nrf_rtc_task_t       task)
 {
     return (uint32_t)p_reg + task;
 }


### PR DESCRIPTION
To minimize the amount of unnedded differences between
the HW models HAL files and the real nRFx HAL files
lets define this macro and use it.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

Note that the definition is practically just a copy of the original one, and in the same file and place as in the original nrfx file