### PR TITLE
HAL: remove not required CMSIS function modeling

### DIFF
--- a/src/nrfx/hal/nrf_soc_if.h
+++ b/src/nrfx/hal/nrf_soc_if.h
@@ -92,12 +92,6 @@ extern void __SEV(void);
 extern void NVIC_SetPendingIRQ(IRQn_Type IRQn);
 extern void NVIC_ClearPendingIRQ(IRQn_Type IRQn);
 
-/**
- * Add empty implementations for some functions that don't need to be simulated.
- */
-static inline void __DMB() {}
-static inline void __NOP() {}
-
 #define NRFX_ASSERT(...)
 
 #ifdef __cplusplus


### PR DESCRIPTION
NOP and DMB intrinsics do not need to be included
in the HW model simulation, so they are removed.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>