### PR TITLE
Add license and copyright info to all source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2019 Oticon A/S
 
 # CMake file to compile this BabbleSim component as a west module in Zephyr
 

--- a/src/HW_models/NRF_bitfields.h
+++ b/src/HW_models/NRF_bitfields.h
@@ -1,6 +1,8 @@
 /*
  * Copy paste of the whole nrf52_bitfields.h
- * (from the nrfx mdk) to be used by the HW models:
+ * (from the nrfx mdk) to be used by the HW models
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 /*
 

--- a/src/HW_models/NRF_regs.h
+++ b/src/HW_models/NRF_regs.h
@@ -1,8 +1,17 @@
-/*
+/**
  * Hacked version of nrf52.h (from the nrfx mdk)
  * without the base addresses, the includes and a few defines
  * to be used by the HW models
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Note that there is a few changes compared to the original
+ * Where relevant, these changes are:
+ * Copyright (c) 2017 Oticon A/S
+ *
+ * The original file header with copyright and license can be found below
  */
+
 #include "NRF_bitfields.h"
 
 /****************************************************************************************************//**

--- a/src/nrfx/hal/nrf_aar.c
+++ b/src/nrfx/hal/nrf_aar.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2020 Oticon A/S
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Note that the function prototypes are taken from the NRFx HAL
+ */
 #include "nrf_aar.h"
 #include "bs_tracing.h"
 #include "NRF_AAR.h"

--- a/src/nrfx/hal/nrf_power.h
+++ b/src/nrfx/hal/nrf_power.h
@@ -1,1 +1,7 @@
+/*
+ * Copyright (c) 2019 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 #include "../drivers/nrfx_common.h"


### PR DESCRIPTION
Ensure all source files have license and copyright info to avoid problems with automatic license checkers