### PR TITLE
nrfx: Allow use of drivers from original nrfx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,17 @@ if(CONFIG_BOARD_NRF52_BSIM)
  https://babblesim.github.io/folder_structure_and_env.html")
   endif()
 
+  # These include directories must be added before those from the hal_nordic
+  # module, so that the local modified versions of nrfx files are used instead
+  # of those from the original nrfx.
+  target_include_directories(zephyr_interface BEFORE INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/nrfx/
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/nrfx/hal/
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/nrfx/mdk/
+  )
+
   zephyr_include_directories(
-    src/
-    src/nrfx/hal/
-    src/nrfx/mdk
-    src/nrfx/
     src/HW_models/
   )
 

--- a/src/nrfx/hal/nrf_clock.h
+++ b/src/nrfx/hal/nrf_clock.h
@@ -372,6 +372,18 @@ void nrf_clock_cal_timer_timeout_set(NRF_CLOCK_Type * p_reg, uint32_t interval);
 
 /* Bodies for inlined functions  */
 
+NRF_STATIC_INLINE uint32_t nrf_clock_task_address_get(NRF_CLOCK_Type const * p_reg,
+                                                      nrf_clock_task_t       task)
+{
+    return (uint32_t)((uint8_t *)p_reg + (uint32_t)task);
+}
+
+NRF_STATIC_INLINE uint32_t nrf_clock_event_address_get(NRF_CLOCK_Type const * p_reg,
+                                                       nrf_clock_event_t      event)
+{
+    return (uint32_t)((uint8_t *)p_reg + (uint32_t)event);
+}
+
 NRF_STATIC_INLINE void nrf_clock_event_clear(NRF_CLOCK_Type * p_reg, nrf_clock_event_t event)
 {
     *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event)) = 0x0UL;

--- a/src/nrfx/hal/nrf_power.h
+++ b/src/nrfx/hal/nrf_power.h
@@ -4,4 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  */
+#ifndef BS_NRF_POWER_H__
+#define BS_NRF_POWER_H__
+
 #include "../drivers/nrfx_common.h"
+
+NRF_STATIC_INLINE uint32_t nrf_power_int_enable_get(NRF_POWER_Type const * p_reg)
+{
+    return p_reg->INTENSET;
+}
+
+#endif /* BS_NRF_POWER_H__ */

--- a/src/nrfx/hal/nrf_soc_if.h
+++ b/src/nrfx/hal/nrf_soc_if.h
@@ -95,7 +95,9 @@ extern void __SEV(void);
 extern void NVIC_SetPendingIRQ(IRQn_Type IRQn);
 extern void NVIC_ClearPendingIRQ(IRQn_Type IRQn);
 
+#ifndef NRFX_ASSERT
 #define NRFX_ASSERT(...)
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Import some more stuff from original nrfx_common.h and change the order
of include directories, to make it possible to override only certain
nrfx files (in particular, HAL and MDK) with their modified versions
from this repository while using other ones (like drivers) in their
original form, directly from the hal_nordic module.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>
Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>