### PR TITLE
nrfx: hal: Add missing nrf_aar_int_enable function

### DIFF
--- a/src/HW_models/NRF_AAR.h
+++ b/src/HW_models/NRF_AAR.h
@@ -19,6 +19,7 @@ void nrf_aar_clean_up();
 
 void nrf_aar_TASK_START();
 void nrf_aar_TASK_STOP() ;
+void nrf_aar_regw_sideeffects_INTENSET();
 void nrf_aar_regw_sideeffects_INTENCLR();
 void nrf_aar_regw_sideeffects_TASKS_START();
 void nrf_aar_regw_sideeffects_TASKS_STOP();

--- a/src/nrfx/hal/nrf_aar.c
+++ b/src/nrfx/hal/nrf_aar.c
@@ -10,6 +10,12 @@
 #include "bs_tracing.h"
 #include "NRF_AAR.h"
 
+void nrf_aar_int_enable(NRF_AAR_Type * p_reg, uint32_t mask)
+{
+  p_reg->INTENSET = mask;
+  nrf_aar_regw_sideeffects_INTENSET();
+}
+
 void nrf_aar_int_disable(NRF_AAR_Type * p_reg, uint32_t mask)
 {
   p_reg->INTENCLR = mask;

--- a/src/nrfx/hal/nrf_aar.h
+++ b/src/nrfx/hal/nrf_aar.h
@@ -85,6 +85,14 @@ NRF_STATIC_INLINE void nrf_aar_event_clear(NRF_AAR_Type *  p_reg,
                                            nrf_aar_event_t event);
 
 /**
+ * @brief Function for enabling the specified interrupts.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be enabled.
+ */
+void nrf_aar_int_enable(NRF_AAR_Type * p_reg, uint32_t mask);
+
+/**
  * @brief Function for disabling the specified interrupts.
  *
  * @param[in] p_reg Pointer to the structure of registers of the peripheral.


### PR DESCRIPTION
Add the missing nrf_aar_int_enable function.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>