### PR TITLE
Makefile: Allow adding a sufix to the library name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ INCLUDES:=-I${libUtilv1_COMP_PATH}/src/ \
           -I${NRFX_BASE} \
           -I${NRFX_BASE}/mdk
 
-
-LIB_NAME:=libNRF52_hw_models.32
+NRF_HW_MODELS_LIB_SUFFIX?=
+LIB_NAME:=libNRF52_hw_models.32${NRF_HW_MODELS_LIB_SUFFIX}
 A_LIBS:=
 A_LIBS32:=
 SO_LIBS:=


### PR DESCRIPTION
As we have more customers & uses for the NRF HW models,
some of them may require some particular versions.
At the same time a user may want to have several of these
dependants all using the same bsim installation.
The only thing complicating this, was that this
Makefile produces the same library from each version.

With this new option, users can add a suffix to the library
name, either as an enviroment option, or a make option.
for ex:
export NRF_HW_MODELS_LIB_SUFFIX=.v1 ; make
NRF_HW_MODELS_LIB_SUFFIX=.v2 make
make NRF_HW_MODELS_LIB_SUFFIX=.v3

With this change, a user may fetch several copies(versions)
of this component in separate component/ folders and
keep them all in parallel building each into a separate
library version.

By default nothing is changed. So this is fully backwards
compatible

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>