### PR TITLE
HW_models: ppi: Route the payload radio event

### DIFF
--- a/src/HW_models/NRF_PPI.c
+++ b/src/HW_models/NRF_PPI.c
@@ -204,6 +204,7 @@ typedef struct {
 static const ppi_event_table_t ppi_events_table[] = { //better keep same order as in ppi_event_types_t
     {RADIO_EVENTS_READY,   &NRF_RADIO_regs.EVENTS_READY},
     {RADIO_EVENTS_ADDRESS, &NRF_RADIO_regs.EVENTS_ADDRESS},
+    {RADIO_EVENTS_PAYLOAD, &NRF_RADIO_regs.EVENTS_PAYLOAD},
     {RADIO_EVENTS_END,     &NRF_RADIO_regs.EVENTS_END},
     {RADIO_EVENTS_DISABLED,&NRF_RADIO_regs.EVENTS_DISABLED},
 //    {RADIO_EVENTS_DEVMATCH,&NRF_RADIO_regs.EVENTS_DEVMATCH},


### PR DESCRIPTION
The payload radio event occurs when a packet's payload (which may be
before the end) is sent or received.

Zephyr Nordic LLL does not need this event, hence it could be left
unrouted, but PacketCraft stack does. This fixes slave reception in
PacketCraft simulation.

Signed-off-by: Mark Ruvald Pedersen <mped@oticon.com>