### PR TITLE
[DNM] Design discussion - introducing 802.15.4 radio model

### DIFF
--- a/src/HW_models/NRF_HW_model_top.c
+++ b/src/HW_models/NRF_HW_model_top.c
@@ -61,7 +61,7 @@ void nrf_hw_initialize(nrf_hw_sub_args_t *args){
   nrf_radio_init();
   nrf_ficr_init();
   nrf_ppi_init();
-  nrf_timer_init();
+  nrf_timer_model_init();
   nrf_hw_find_next_timer_to_trigger();
 }
 

--- a/src/HW_models/NRF_TIMER.c
+++ b/src/HW_models/NRF_TIMER.c
@@ -39,7 +39,8 @@ static bs_time_t CC_timers[N_TIMERS][N_CC] = {{TIME_NEVER}};
 /**
  * Initialize the TIMER model
  */
-void nrf_timer_init(){
+
+void nrf_timer_model_init(){
   memset(NRF_TIMER_regs, 0, sizeof(NRF_TIMER_regs));
   for (int t = 0; t < N_TIMERS ; t++ ){
     TIMER_INTEN[t] = 0;

--- a/src/HW_models/NRF_TIMER.h
+++ b/src/HW_models/NRF_TIMER.h
@@ -12,7 +12,8 @@
 extern "C"{
 #endif
 
-void nrf_timer_init();
+
+void nrf_timer_model_init();
 void nrf_timer_clean_up();
 void nrf_timer_timer_triggered();
 

--- a/src/HW_models/core_cm4.h
+++ b/src/HW_models/core_cm4.h
@@ -11,9 +11,15 @@
 #ifndef CORE_CM4__
 #define CORE_CM4__
 
+#include <stdint.h>
+
 #define __I
 #define __IO
 #define __O
+
+#define __IM
+#define __OM
+#define __IOM
 
 /**
  * The model of the CPU & IRQ controller driver must provide
@@ -46,4 +52,4 @@ extern void NVIC_ClearPendingIRQ(IRQn_Type IRQn);
 #define __NOP()
 #endif
 
-#endif 
+#endif

--- a/src/nrfx/mdk_replacements/nrf_bsim_redef.h
+++ b/src/nrfx/mdk_replacements/nrf_bsim_redef.h
@@ -88,6 +88,7 @@ extern NRF_EGU_Type NRF_EGU_regs[6];
 #undef NRF_EGU5_BASE
 #define NRF_EGU5_BASE                     (&NRF_EGU_regs[5])
 
+
 /*
  * Redefine the peripheral pointers
  */


### PR DESCRIPTION
@aescolar In this PR we would like to discuss the way of adding the support for 802.15.4 radio.

Our approach is to add a relatively generic 802.15.4 radio model, which would be based on the nRF52840 radio.
The new model would be attached to the build with a Kconfig option.

On the Zephyr's side, SOC_COMPATIBLE_NRF52832 would be changed to a different option when 802.15.4 radio is enabled.
Initially, SOC_COMPATIBLE_NRF52840 can be introduced to enable including nrf52840 headers instead of nrf52832'.
That's a subject for discussion how to include the right headers. Perhaps, creating dedicated headers for
nrf52_bsim only could be an alternative.

The changes in zephyr are in this PR: https://github.com/zephyrproject-rtos/zephyr/pull/47028

The reason for adding suplementary radio model instead of creating a new simulated platform is that modeled peripherals
don't differ significantly between nRF boards and adding different simulated platforms for each board would be redundant.

FYI: @czeslawmakarski @rugeGerritsen 