### PR TITLE
Resolving function name conflict.

### DIFF
--- a/src/HW_models/NRF_HW_model_top.c
+++ b/src/HW_models/NRF_HW_model_top.c
@@ -34,7 +34,7 @@ void nrf_hw_models_free_all(){
   nrf_radio_clean_up();
   nrf_ficr_clean_up();
   nrf_ppi_clean_up();
-  nrf_timer_clean_up();
+  nrf_hw_model_timer_clean_up();
 }
 
 /*
@@ -61,7 +61,7 @@ void nrf_hw_initialize(nrf_hw_sub_args_t *args){
   nrf_radio_init();
   nrf_ficr_init();
   nrf_ppi_init();
-  nrf_timer_init();
+  nrf_hw_model_timer_init();
   nrf_hw_find_next_timer_to_trigger();
 }
 
@@ -178,7 +178,7 @@ void nrf_hw_some_timer_reached() {
     break;
   case TIMER_timer:
     bs_trace_raw_manual_time(8, tm_get_abs_time(),"NRF HW: TIMERx timer\n");
-    nrf_timer_timer_triggered();
+    nrf_hw_model_timer_timer_triggered();
     break;
   case RADIO_timer:
     bs_trace_raw_manual_time(8, tm_get_abs_time(),"NRF HW: RADIO timer\n");

--- a/src/HW_models/NRF_TIMER.c
+++ b/src/HW_models/NRF_TIMER.c
@@ -39,7 +39,7 @@ static bs_time_t CC_timers[N_TIMERS][N_CC] = {{TIME_NEVER}};
 /**
  * Initialize the TIMER model
  */
-void nrf_timer_init(){
+void nrf_hw_model_timer_init(){
   memset(NRF_TIMER_regs, 0, sizeof(NRF_TIMER_regs));
   for (int t = 0; t < N_TIMERS ; t++ ){
     TIMER_INTEN[t] = 0;
@@ -56,7 +56,7 @@ void nrf_timer_init(){
 /**
  * Clean up the TIMER model before program exit
  */
-void nrf_timer_clean_up(){
+void nrf_hw_model_timer_clean_up(){
 
 }
 
@@ -322,7 +322,7 @@ void nrf_timer_regw_sideeffects_CC(int t, int cc_n){
   }
 }
 
-void nrf_timer_timer_triggered() {
+void nrf_hw_model_timer_timer_triggered() {
   for ( int t = 0 ; t < N_TIMERS ; t++) {
     if ( !(( Timer_running[t] == true ) && ( NRF_TIMER_regs[t].MODE == 0 )) ) {
       continue;

--- a/src/HW_models/NRF_TIMER.h
+++ b/src/HW_models/NRF_TIMER.h
@@ -12,9 +12,9 @@
 extern "C"{
 #endif
 
-void nrf_timer_init();
-void nrf_timer_clean_up();
-void nrf_timer_timer_triggered();
+void nrf_hw_model_timer_init();
+void nrf_hw_model_timer_clean_up();
+void nrf_hw_model_timer_timer_triggered();
 
 extern NRF_TIMER_Type NRF_TIMER_regs[];
 


### PR DESCRIPTION
Hi @aescolar . During work on the support for 802.15.4 radio, we found the function name conflict - the same function name occur in the radio driver source code and in the babblesim as well. If you do not mind I will change it here.